### PR TITLE
Only check for required options

### DIFF
--- a/src/bundles/create-async-resource-bundle.js
+++ b/src/bundles/create-async-resource-bundle.js
@@ -1,8 +1,6 @@
 import { createSelector } from 'create-selector'
 
 const defaultOpts = {
-  name: null,
-  getPromise: null,
   actionBaseType: null,
   staleAfter: 900000, // fifteen minutes
   retryAfter: 60000, // one minute,
@@ -11,8 +9,24 @@ const defaultOpts = {
   persist: true
 }
 
+const requiredOpts = {
+  name: null,
+  getPromise: null
+}
+
 export default spec => {
-  const opts = Object.assign({}, defaultOpts, spec)
+  const opts = Object.assign({}, requiredOpts, defaultOpts, spec)
+
+  if (process.env.NODE_ENV !== 'production') {
+    for (const item in requiredOpts) {
+      if (opts[item] === null) {
+        throw Error(
+          `You must supply an ${item} option when creating a resource bundle`
+        )
+      }
+    }
+  }
+
   const {
     name,
     staleAfter,
@@ -21,18 +35,9 @@ export default spec => {
     checkIfOnline,
     expireAfter
   } = opts
+
   const uCaseName = name.charAt(0).toUpperCase() + name.slice(1)
   const baseType = actionBaseType || name.toUpperCase()
-
-  if (process.env.NODE_ENV !== 'production') {
-    for (const item in opts) {
-      if (opts[item] === null) {
-        throw Error(
-          `You must supply an ${item} option when creating a resource bundle`
-        )
-      }
-    }
-  }
 
   // build selectors
   const inputSelector = state => state[name]

--- a/src/bundles/create-async-resource-bundle.js
+++ b/src/bundles/create-async-resource-bundle.js
@@ -9,22 +9,18 @@ const defaultOpts = {
   persist: true
 }
 
-const requiredOpts = {
-  name: null,
-  getPromise: null
-}
-
 export default spec => {
-  const opts = Object.assign({}, requiredOpts, defaultOpts, spec)
+  const opts = Object.assign({}, defaultOpts, spec)
 
   if (process.env.NODE_ENV !== 'production') {
-    for (const item in requiredOpts) {
-      if (opts[item] === null) {
+    const requiredOptions = ['name', 'getPromise']
+    requiredOptions.forEach(requiredOption => {
+      if (!opts[requiredOption]) {
         throw Error(
-          `You must supply an ${item} option when creating a resource bundle`
+          `You must supply a ${requiredOption} option when creating a resource bundle.`
         )
       }
-    }
+    })
   }
 
   const {


### PR DESCRIPTION
`actionBaseType` should be optional, but the options checker looks for *all* fields to be not null.

The easiest way to do this seemed to be splitting out required from optional settings and running the check of merged options against the required options only. Hoisting the 'checker' also throws if `name` is missing before trying to split it.

In order to test this without repeating the `getAsyncBundleStore` I added an optional second parameter to merge any additional options into `createAsyncResourceBundle`.

Open to any feedback or changes!
