### PR TITLE
Parameterise the selector for create-route-bundle

### DIFF
--- a/docs/api/included-bundles.md
+++ b/docs/api/included-bundles.md
@@ -74,7 +74,7 @@ Selectors:
 * `selectHostname()`: returns hostname as string.
 * `selectSubdomains()`: returns array of subdomains, if relevant.
 
-## `createRouteBundle(routesObject)`
+## `createRouteBundle(routesObject, optionsObject)`
 
 Takes an object of routes and returns a bundle with selectors to extract route parameters from the routes.
 
@@ -93,10 +93,25 @@ The value like `Home`, `UserList`, etc, can be _anything_. Whatever the current 
 
 Then in your root component in your app you'd simply `selectRoute()` to retrieve it.
 
+Options object:
+
+* `routeInfoSelector`: String (default: `'selectPathname'`) used to configure the key that is used for matching the current route on. Set it to `'selectHash'` to enable hash-based routing. **Note**: Currently you need entries for both '' and '/' if you rely on hash-based routing.
+
+```js
+export default createRouteBundle({
+  '': Home,
+  '/': Home,
+  '/users': UserList,
+}, {
+  routeInfoSelector: 'selectHash'
+})
+```
+
 Selectors:
 
 `selectRouteParams()`: returns an object of any route params extracted based on current route and current URL. In the example above `/users/:userId` would return `{userId: 'valueExtractedFromURL'}`.
 `selectRoute()`: returns whatever the value was in the routes object for the current matched route.
+`selectRouteInfo()`: returns the key that was passed to the route matcher. By default this is the value of `selectPathname` as defined by the `createUrlBundle` above.
 
 ## `appTimeBundle`
 

--- a/src/bundles/create-route-bundle.js
+++ b/src/bundles/create-route-bundle.js
@@ -1,9 +1,9 @@
 import { createSelector } from 'create-selector'
 import createRouteMatcher from 'feather-route-matcher'
 
-export default routes => ({
+export default (routes, routeInfoSelector = 'selectPathname') => ({
   name: 'routes',
-  selectRouteInfo: createSelector('selectPathname', createRouteMatcher(routes)),
+  selectRouteInfo: createSelector(routeInfoSelector, createRouteMatcher(routes)),
   selectRouteParams: createSelector('selectRouteInfo', ({ params }) => params),
   selectRoute: createSelector('selectRouteInfo', ({ page }) => page)
 })

--- a/src/bundles/create-route-bundle.js
+++ b/src/bundles/create-route-bundle.js
@@ -1,9 +1,17 @@
 import { createSelector } from 'create-selector'
 import createRouteMatcher from 'feather-route-matcher'
 
-export default (routes, routeInfoSelector = 'selectPathname') => ({
-  name: 'routes',
-  selectRouteInfo: createSelector(routeInfoSelector, createRouteMatcher(routes)),
-  selectRouteParams: createSelector('selectRouteInfo', ({ params }) => params),
-  selectRoute: createSelector('selectRouteInfo', ({ page }) => page)
-})
+const defaults = {
+  routeInfoSelector: 'selectPathname'
+}
+
+export default (routes, spec) => {
+  const opts = Object.assign({}, defaults, spec)
+  const { routeInfoSelector } = opts
+  return {
+    name: 'routes',
+    selectRouteInfo: createSelector(routeInfoSelector, createRouteMatcher(routes)),
+    selectRouteParams: createSelector('selectRouteInfo', ({ params }) => params),
+    selectRoute: createSelector('selectRouteInfo', ({ page }) => page)
+  }
+}


### PR DESCRIPTION
By letting the user pass in the selector to use to get the routeInfo they can override the default with `selectHash`, which allows hash based routing in their app.

e.g.
```js
export default createRouteBundle({
  '/': HomePage,
  '/people': PeoplePage,
  '/people/:id': PersonDetailPage
}, 'selectHash')
```