### PR TITLE
createAsyncResourceBundle selectors use names instead of references

### DIFF
--- a/src/bundles/create-async-resource-bundle.js
+++ b/src/bundles/create-async-resource-bundle.js
@@ -36,17 +36,29 @@ export default spec => {
   const baseType = actionBaseType || name.toUpperCase()
 
   // build selectors
+  const inputSelectorName = `select${uCaseName}Raw`
   const inputSelector = state => state[name]
-  const dataSelector = state => state[name].data
-  const lastSuccessSelector = state => state[name].lastSuccess
-  const isExpiredSelector = state => state[name].isExpired
+  const dataSelectorName = `select${uCaseName}`
+  const dataSelector = createSelector(inputSelectorName, root => root.data)
+  const lastSuccessSelectorName = `select${uCaseName}LastSuccess`
+  const lastSuccessSelector = createSelector(
+    inputSelectorName,
+    root => root.lastSuccess
+  )
+  const isExpiredSelectorName = `select${uCaseName}IsExpired`
+  const isExpiredSelector = createSelector(
+    inputSelectorName,
+    root => root.isExpired
+  )
+  const lastErrorSelectorName = `select${uCaseName}LastError`
   const lastErrorSelector = createSelector(
-    inputSelector,
+    inputSelectorName,
     resource => resource.errorTimes.slice(-1)[0] || null
   )
+  const isStaleSelectorName = `select${uCaseName}IsStale`
   const isStaleSelector = createSelector(
-    inputSelector,
-    lastSuccessSelector,
+    inputSelectorName,
+    lastSuccessSelectorName,
     'selectAppTime',
     (state, time, appTime) => {
       if (state.isOutdated) {
@@ -58,8 +70,9 @@ export default spec => {
       return appTime - time > staleAfter
     }
   )
+  const isWaitingToRetrySelectorName = `select${uCaseName}IsWaitingToRetry`
   const isWaitingToRetrySelector = createSelector(
-    lastErrorSelector,
+    lastErrorSelectorName,
     'selectAppTime',
     (time, appTime) => {
       if (!time) {
@@ -68,20 +81,23 @@ export default spec => {
       return appTime - time < retryAfter
     }
   )
+  const isLoadingSelectorName = `select${uCaseName}IsLoading`
   const isLoadingSelector = createSelector(
-    inputSelector,
+    inputSelectorName,
     resourceState => resourceState.isLoading
   )
+  const failedPermanentlySelectorName = `select${uCaseName}FailedPermanently`
   const failedPermanentlySelector = createSelector(
-    inputSelector,
+    inputSelectorName,
     resourceState => resourceState.failedPermanently
   )
+  const shouldUpdateSelectorName = `select${uCaseName}ShouldUpdate`
   const shouldUpdateSelector = createSelector(
-    isLoadingSelector,
-    failedPermanentlySelector,
-    isWaitingToRetrySelector,
-    dataSelector,
-    isStaleSelector,
+    isLoadingSelectorName,
+    failedPermanentlySelectorName,
+    isWaitingToRetrySelectorName,
+    dataSelectorName,
+    isStaleSelectorName,
     'selectIsOnline',
     (
       isLoading,
@@ -194,15 +210,16 @@ export default spec => {
       }
       return state
     },
-    [`select${uCaseName}Raw`]: inputSelector,
-    [`select${uCaseName}`]: dataSelector,
-    [`select${uCaseName}IsStale`]: isStaleSelector,
-    [`select${uCaseName}IsExpired`]: isExpiredSelector,
-    [`select${uCaseName}LastError`]: lastErrorSelector,
-    [`select${uCaseName}IsWaitingToRetry`]: isWaitingToRetrySelector,
-    [`select${uCaseName}IsLoading`]: isLoadingSelector,
-    [`select${uCaseName}FailedPermanently`]: failedPermanentlySelector,
-    [`select${uCaseName}ShouldUpdate`]: shouldUpdateSelector,
+    [inputSelectorName]: inputSelector,
+    [dataSelectorName]: dataSelector,
+    [isStaleSelectorName]: isStaleSelector,
+    [isExpiredSelectorName]: isExpiredSelector,
+    [lastErrorSelectorName]: lastErrorSelector,
+    [lastSuccessSelectorName]: lastSuccessSelector,
+    [isWaitingToRetrySelectorName]: isWaitingToRetrySelector,
+    [isLoadingSelectorName]: isLoadingSelector,
+    [failedPermanentlySelectorName]: failedPermanentlySelector,
+    [shouldUpdateSelectorName]: shouldUpdateSelector,
     [`doFetch${uCaseName}`]: doFetchData,
     [`doMark${uCaseName}AsOutdated`]: doMarkAsOutdated,
     [`doClear${uCaseName}`]: doClear,


### PR DESCRIPTION
This allows much more flexibility for bundle composition.