### PR TITLE
#46: added `maintainScrollPosition` param to URL bundle

### DIFF
--- a/docs/api/included-bundles.md
+++ b/docs/api/included-bundles.md
@@ -57,8 +57,8 @@ Options object:
 
 Action creators:
 
-* `doUpdateUrl(pathname | {pathname,query,hash}, [options])`: Generic URL updating action creator. You can pass it any pathname string or an object with `pathname`, `query`, and `hash` keys. ex: `doUpdateUrl('/new-path')`, `doUpdateUrl('/new-path?some=value#hash')`. You can pass `{replace: true}` as an option to trigger `replaceState` instead of `pushState`.
-  `doReplaceUrl(pathname | {pathname,query,hash})`: just like `doUpdateUrl` but replace is prefilled to replace current URL.
+* `doUpdateUrl(pathname | {pathname,query,hash}, [options])`: Generic URL updating action creator. You can pass it any pathname string or an object with `pathname`, `query`, and `hash` keys. ex: `doUpdateUrl('/new-path')`, `doUpdateUrl('/new-path?some=value#hash')`. You can pass `{replace: true}` as an option to trigger `replaceState` instead of `pushState`. Additionally, you can pass `{ maintainScrollPosition: true }` for cases when you do not expect window scroll position to be reset to top as a result of route transition.
+* `doReplaceUrl(pathname | {pathname,query,hash})`: just like `doUpdateUrl` but replace is prefilled to replace current URL.
 * `doUpdateQuery(queryString | queryObject, [options])`: can be used to update query string in place. Either pass in new query string or an object. It does a replaceState by default but you can pass `{replace: false}` if you want to do a push.
 * `doUpdateHash(string | object, [options])`: for updating hash value, does a push by default, but can do replace if passed `{replace: true}`.
 

--- a/src/bundles/create-url-bundle.js
+++ b/src/bundles/create-url-bundle.js
@@ -76,7 +76,7 @@ export default opts => {
     parseSubdomains(hostname)
   )
 
-  const doUpdateUrl = (newState, opts = { replace: false }) => ({
+  const doUpdateUrl = (newState, opts = { replace: false, maintainScrollPosition: false }) => ({
     dispatch,
     getState
   }) => {
@@ -97,7 +97,11 @@ export default opts => {
     if (isDefined(state.query)) url.search = ensureString(state.query)
     dispatch({
       type: actionType,
-      payload: { url: url.href, replace: opts.replace }
+      payload: {
+        url: url.href,
+        replace: opts.replace,
+        maintainScrollPosition: opts.maintainScrollPosition
+      }
     })
   }
   const doReplaceUrl = url => doUpdateUrl(url, { replace: true })
@@ -140,7 +144,9 @@ export default opts => {
             if (config.handleScrollRestoration) {
               saveScrollPosition()
             }
-            window.scrollTo(0, 0)
+            if (!newState.maintainScrollPosition) {
+              window.scrollTo(0, 0)
+            }
           } catch (e) {
             console.error(e)
           }
@@ -151,20 +157,23 @@ export default opts => {
     getReducer: () => {
       const initialState = {
         url: !config.inert && HAS_WINDOW ? loc.href : '/',
-        replace: false
+        replace: false,
+        maintainScrollPosition: false
       }
 
       return (state = initialState, { type, payload }) => {
         if (typeof state === 'string') {
           return {
             url: state,
-            replace: false
+            replace: false,
+            maintainScrollPosition: false
           }
         }
         if (type === actionType) {
           return Object.assign({
             url: payload.url || payload,
-            replace: !!payload.replace
+            replace: !!payload.replace,
+            maintainScrollPosition: !!payload.maintainScrollPosition
           })
         }
         return state

--- a/test/url-bundle.js
+++ b/test/url-bundle.js
@@ -8,7 +8,7 @@ test('url-bundle selectors', t => {
   const store = composeBundlesRaw(createUrlBundle())({ url: startUrl })
   t.deepEqual(
     store.selectUrlRaw(),
-    { url: startUrl, replace: false },
+    { url: startUrl, replace: false, maintainScrollPosition: false },
     'returns basic start'
   )
   // make sure object will be serializable
@@ -33,7 +33,11 @@ test('url-bundle selectors', t => {
   )
 
   const store2 = composeBundlesRaw(createUrlBundle())()
-  t.deepEqual(store2.selectUrlRaw(), { url: '/', replace: false })
+  t.deepEqual(store2.selectUrlRaw(), {
+    url: '/',
+    replace: false,
+    maintainScrollPosition: false
+  })
   t.end()
 })
 
@@ -48,35 +52,40 @@ test('url-bundle actionCreators', t => {
   store.doUpdateUrl('/')
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/',
-    replace: false
+    replace: false,
+    maintainScrollPosition: false
   })
 
   resetStore()
   store.doUpdateUrl('/', { replace: true })
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/',
-    replace: true
+    replace: true,
+    maintainScrollPosition: false
   })
 
   resetStore()
   store.doReplaceUrl('/hi')
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/hi',
-    replace: true
+    replace: true,
+    maintainScrollPosition: false
   })
 
   resetStore()
   store.doUpdateQuery({ ok: 'hi' })
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/something?ok=hi',
-    replace: true
+    replace: true,
+    maintainScrollPosition: false
   })
 
   resetStore()
   store.doUpdateQuery('ok=hi')
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/something?ok=hi',
-    replace: true
+    replace: true,
+    maintainScrollPosition: false
   })
   t.deepEqual(store.selectQueryObject(), { ok: 'hi' })
 
@@ -84,19 +93,25 @@ test('url-bundle actionCreators', t => {
   store.doUpdateHash({ ok: 'hi' })
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/something#ok=hi',
-    replace: false
+    replace: false,
+    maintainScrollPosition: false
   })
 
   resetStore()
   store.doUpdateUrl('/hi?there=you#something')
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/hi?there=you#something',
-    replace: false
+    replace: false,
+    maintainScrollPosition: false
   })
   store.doUpdateUrl('/boo')
   t.deepEqual(
     store.selectUrlRaw(),
-    { url: 'http://something.com/boo', replace: false },
+    {
+      url: 'http://something.com/boo',
+      replace: false,
+      maintainScrollPosition: false
+    },
     'clears existing when passing full string'
   )
 
@@ -104,14 +119,24 @@ test('url-bundle actionCreators', t => {
   store.doUpdateUrl('/hi?there=you')
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/hi?there=you',
-    replace: false
+    replace: false,
+    maintainScrollPosition: false
   })
 
   resetStore()
   store.doUpdateUrl('/hi#something')
   t.deepEqual(store.selectUrlRaw(), {
     url: 'http://something.com/hi#something',
-    replace: false
+    replace: false,
+    maintainScrollPosition: false
+  })
+
+  resetStore()
+  store.doUpdateUrl('/hi', { maintainScrollPosition: true })
+  t.deepEqual(store.selectUrlRaw(), {
+    url: 'http://something.com/hi',
+    replace: false,
+    maintainScrollPosition: true
   })
 
   t.end()


### PR DESCRIPTION
Extended `doUpdateUrl` from URL bundle with additional parameter `maintainScrollPosition` that would not reset scroll to window top when changing route.