### PR TITLE
Feature/add destroy function to store

### DIFF
--- a/docs/api/bundle.md
+++ b/docs/api/bundle.md
@@ -51,6 +51,45 @@ This will be run _once_ as a last step before the store is returned. It will be 
 
 For example, you may want redux to track current viewport width so that other selectors can change behavior based on viewport size. You could create a `viewport` bundle and register a debounced event listener for the `resize` event on window, and then dispatch a `WINDOW_RESIZED` action with the new width/height and add a `selectIsMobileViewport` selector to make it available to other bundles.
 
+Additionally, you can return a function that behaves the same as `bundle.destroy()` in order to cleanup state, remove event listeners, etc.
+
+```js
+export const onlineBundle = {
+  // ...
+
+  init(store) {
+    const handleOnline = () => store.dispatch({ type: 'ONLINE' })
+    const handleOffline = () => store.dispatch({ type: 'OFFLINE' })
+
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }
+
+  // ...
+}
+```
+
+## `bundle.destroy`
+
+Same as returning a function from `bundle.init`, you may explicitly declare a destroy function.
+
+```js
+export const resetStoreBundle = {
+  // ...
+
+  destroy(store) {
+    store.dispatch({ type: 'REPLACE_STATE', payload: null })
+  }
+
+  // ...
+}
+```
+
 ## `bundle.persistActions`
 
 If the caching bundle is configured it will look for this property from other bundles. It should contain an array of action types that should cause contents of this bundle's reducer to be persisted to cache. These action types will be used by some generated redux middleware to lazily persist the contents of the reducer any time these actions occur.

--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -53,6 +53,10 @@ Lets you dispatch an action creator by name. Give it the name of the action crea
 
 This utility exists to simplify support for propagating actions from main thread to web worker or vice versa.
 
+## `store.destroy()`
+
+Lets you remove event listeners, cleanup state and unsubscribe from store listeners. This calls the destroy implementation for every bundle. It is a 1-way function and the store cannot be re-initialized afterwards. Handy if you want to programmatically unmount an app.
+
 ## Special `BATCH_ACTIONS` action type
 
 If you dispatch an action that looks like this `{type: 'BATCH_ACTIONS', actions: [array of other actions]}` it will dispatch them all in one update cycle. Rather than calling all callbacks at once, it will process all actions through all reducers then call the functions. These should be prepared "simple" action objects, not async actions that return a thunk function.

--- a/src/bundles/create-reactor-bundle.js
+++ b/src/bundles/create-reactor-bundle.js
@@ -86,7 +86,9 @@ export default spec => ({
       }
     }
 
-    store.subscribe(callback)
+    const unsubscribe = store.subscribe(callback)
     callback()
+
+    return () => unsubscribe()
   }
 })

--- a/src/bundles/create-reactor-bundle.js
+++ b/src/bundles/create-reactor-bundle.js
@@ -89,6 +89,9 @@ export default spec => ({
     const unsubscribe = store.subscribe(callback)
     callback()
 
-    return () => unsubscribe()
+    return () => {
+      idleDispatcher && idleDispatcher.cancel()
+      unsubscribe()
+    }
   }
 })

--- a/src/bundles/create-url-bundle.js
+++ b/src/bundles/create-url-bundle.js
@@ -129,17 +129,18 @@ export default opts => {
         initScrollPosition()
       }
 
-      window.addEventListener('popstate', () => {
+      const popStateFn = () => {
         store.doUpdateUrl({
           pathname: loc.pathname,
           hash: loc.hash,
           query: loc.search
         })
-      })
+      }
+      window.addEventListener('popstate', popStateFn)
 
       let lastState = store.selectUrlRaw()
 
-      store.subscribe(() => {
+      const unsubscribe = store.subscribe(() => {
         const newState = store.selectUrlRaw()
         const newUrl = newState.url
         if (lastState !== newState && newUrl !== loc.href) {
@@ -161,6 +162,11 @@ export default opts => {
         }
         lastState = newState
       })
+
+      return () => {
+        window.removeEventListener('popstate', popStateFn)
+        unsubscribe()
+      }
     },
     getReducer: () => {
       const initialState = {

--- a/src/bundles/create-url-bundle.js
+++ b/src/bundles/create-url-bundle.js
@@ -1,6 +1,11 @@
 import qs from 'querystringify'
 import { createSelector } from 'create-selector'
-import { HAS_WINDOW, initScrollPosition, saveScrollPosition } from '../utils'
+import {
+  addGlobalListener,
+  HAS_WINDOW,
+  initScrollPosition,
+  saveScrollPosition
+} from '../utils'
 
 export const isString = obj =>
   Object.prototype.toString.call(obj) === '[object String]'

--- a/src/bundles/online.js
+++ b/src/bundles/online.js
@@ -7,7 +7,7 @@ export default {
   name: 'online',
   selectIsOnline: state => state.online,
 
-  getReducer() {
+  getReducer () {
     const initialState = IS_BROWSER ? navigator.onLine : true
 
     return (state = initialState, { type }) => {
@@ -18,7 +18,7 @@ export default {
     }
   },
 
-  init(store) {
+  init (store) {
     const removeOnlineListener = addGlobalListener('online', () =>
       store.dispatch({ type: ONLINE })
     )

--- a/src/bundles/online.js
+++ b/src/bundles/online.js
@@ -6,16 +6,29 @@ const ONLINE = 'ONLINE'
 export default {
   name: 'online',
   selectIsOnline: state => state.online,
-  getReducer: () => {
+
+  getReducer() {
     const initialState = IS_BROWSER ? navigator.onLine : true
+
     return (state = initialState, { type }) => {
       if (type === OFFLINE) return false
       if (type === ONLINE) return true
+
       return state
     }
   },
-  init: store => {
-    addGlobalListener('online', () => store.dispatch({ type: ONLINE }))
-    addGlobalListener('offline', () => store.dispatch({ type: OFFLINE }))
+
+  init(store) {
+    const removeOnlineListener = addGlobalListener('online', () =>
+      store.dispatch({ type: ONLINE })
+    )
+    const removeOfflineListener = addGlobalListener('offline', () =>
+      store.dispatch({ type: OFFLINE })
+    )
+
+    return () => {
+      removeOnlineListener()
+      removeOfflineListener()
+    }
   }
 }

--- a/src/compose/consume-bundle.js
+++ b/src/compose/consume-bundle.js
@@ -8,6 +8,7 @@ export const normalizeBundle = bundle => {
     reducer:
       bundle.reducer || (bundle.getReducer && bundle.getReducer()) || null,
     init: bundle.init || null,
+    destroy: bundle.destroy || null,
     extraArgCreators: bundle.getExtraArgs || null,
     middlewareCreators: bundle.getMiddleware,
     actionCreators: null,
@@ -43,6 +44,7 @@ export const createChunk = rawBundles => {
     rawBundles: [],
     processedBundles: [],
     initMethods: [],
+    destroyMethods: [],
     middlewareCreators: [],
     extraArgCreators: [],
     reactorNames: []
@@ -55,6 +57,7 @@ export const createChunk = rawBundles => {
       Object.assign(result.reducers, { [bundle.name]: bundle.reducer })
     }
     if (bundle.init) result.initMethods.push(bundle.init)
+    if (bundle.destroy) result.destroyMethods.push(bundle.destroy)
     if (bundle.middlewareCreators) {
       result.middlewareCreators.push(bundle.middlewareCreators)
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,9 +126,22 @@ export const initScrollPosition = () => {
   if (history.scrollRestoration) {
     history.scrollRestoration = 'manual'
   }
-  addGlobalListener('popstate', restoreScrollPosition)
-  addGlobalListener('scroll', debounce(saveScrollPosition, 300), {
-    passive: true
-  })
+  const removePopstateListener = addGlobalListener(
+    'popstate',
+    restoreScrollPosition
+  )
+  const removeScrollListener = addGlobalListener(
+    'scroll',
+    debounce(saveScrollPosition, 300),
+    {
+      passive: true
+    }
+  )
+
   restoreScrollPosition()
+
+  return () => {
+    removePopstateListener()
+    removeScrollListener()
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,17 +58,17 @@ export const addGlobalListener = (
   handler,
   opts = { passive: false }
 ) => {
-  if (IS_BROWSER) {
-    if (opts.passive) {
-      if (PASSIVE_EVENTS_SUPPORTED) {
-        self.addEventListener(eventName, handler, { passive: true })
-      } else {
-        self.addEventListener(eventName, debounce(handler, 200), false)
-      }
-    } else {
-      self.addEventListener(eventName, handler)
-    }
-  }
+  if (!IS_BROWSER) return () => undefined
+
+  const args = opts.passive
+    ? PASSIVE_EVENTS_SUPPORTED
+      ? [eventName, handler, { passive: true }]
+      : [eventName, debounce(handler, 200), false]
+    : [eventName, handler]
+
+  self.addEventListener(...args)
+
+  return () => self.removeEventListener(...args)
 }
 
 export const selectorNameToValueName = name => {

--- a/test/bundles/create-async-resource-bundle.js
+++ b/test/bundles/create-async-resource-bundle.js
@@ -5,7 +5,7 @@ const {
   createReactorBundle,
   composeBundlesRaw,
   onlineBundle
-} = require('../dist/redux-bundler')
+} = require('../../dist/redux-bundler')
 
 const getAsyncBundleStore = (result, bundleOptions) =>
   composeBundlesRaw(

--- a/test/bundles/create-cache-bundle.js
+++ b/test/bundles/create-cache-bundle.js
@@ -2,7 +2,7 @@ const test = require('tape')
 const {
   composeBundlesRaw,
   createCacheBundle
-} = require('../dist/redux-bundler')
+} = require('../../dist/redux-bundler')
 
 const getTestBundle = (number, startingState = {}, persistActions) => ({
   name: `test${number}`,

--- a/test/bundles/create-debug-bundle.js
+++ b/test/bundles/create-debug-bundle.js
@@ -2,7 +2,7 @@ const test = require('tape')
 const {
   composeBundlesRaw,
   createDebugBundle
-} = require('../dist/redux-bundler')
+} = require('../../dist/redux-bundler')
 
 test('create debug bundle basics', t => {
   const store = composeBundlesRaw(createDebugBundle(), {

--- a/test/bundles/create-reactor-bundle.js
+++ b/test/bundles/create-reactor-bundle.js
@@ -2,7 +2,7 @@ const test = require('tape')
 const {
   composeBundlesRaw,
   createReactorBundle
-} = require('../dist/redux-bundler')
+} = require('../../dist/redux-bundler')
 
 const ACTION_0 = 'ACTION_0'
 const ACTION_1 = 'ACTION_1'

--- a/test/bundles/create-route-bundle.js
+++ b/test/bundles/create-route-bundle.js
@@ -5,7 +5,7 @@ const {
   composeBundlesRaw,
   createRouteBundle,
   createUrlBundle
-} = require('../dist/redux-bundler')
+} = require('../../dist/redux-bundler')
 
 test('create-route-bundle', t => {
   const startUrl = 'http://subdomain.something.com:3030/something#hi=there'

--- a/test/bundles/create-url-bundle.js
+++ b/test/bundles/create-url-bundle.js
@@ -1,7 +1,10 @@
 // polyfill URL for node
 global.URL = require('whatwg-url').URL
 const test = require('tape')
-const { composeBundlesRaw, createUrlBundle } = require('../dist/redux-bundler')
+const {
+  composeBundlesRaw,
+  createUrlBundle
+} = require('../../dist/redux-bundler')
 
 test('url-bundle selectors', t => {
   const startUrl = 'http://subdomain.something.com:3030/something#hi=there'

--- a/test/destroy.js
+++ b/test/destroy.js
@@ -1,0 +1,61 @@
+const test = require('tape')
+const { composeBundles, composeBundlesRaw } = require('../dist/redux-bundler')
+
+const countBundle = {
+  name: 'count',
+  selectDestroyable: state => state.destroyable,
+  reducer: (state = 0, { type }) => (type === 'INC' ? state + 1 : state)
+}
+
+test('makes destroy available to store', t => {
+  const createStore = composeBundles()
+  t.equal(typeof createStore().destroy, 'function', 'destroy is a function')
+  t.end()
+})
+
+test('calls destroy with store', t => {
+  const store = composeBundlesRaw({
+    ...countBundle,
+    destroy(store) {
+      store.destroyed = true
+    }
+  })()
+  t.equal(store.destroyed, undefined)
+
+  store.destroy()
+
+  t.equal(store.destroyed, true)
+
+  t.end()
+})
+
+test('calls return of init as the destroy of store', t => {
+  let count = 0
+  const store = composeBundlesRaw({
+    ...countBundle,
+    init(store) {
+      // being explicit here for documentation purposes
+      const unsubscribe = store.subscribe(() => {
+        count++
+      })
+
+      return () => {
+        unsubscribe()
+      }
+    }
+  })()
+
+  t.equal(count, 0)
+
+  store.dispatch({ type: 'INC' })
+  t.equal(store.getState().count, 1)
+  t.equal(count, 1)
+
+  store.destroy()
+
+  store.dispatch({ type: 'INC' })
+  t.equal(store.getState().count, 2)
+  t.equal(count, 1, 'destroy should have unsubscribed')
+
+  t.end()
+})

--- a/test/destroy.js
+++ b/test/destroy.js
@@ -16,7 +16,7 @@ test('makes destroy available to store', t => {
 test('calls destroy with store', t => {
   const store = composeBundlesRaw({
     ...countBundle,
-    destroy(store) {
+    destroy (store) {
       store.destroyed = true
     }
   })()
@@ -33,7 +33,7 @@ test('calls return of init as the destroy of store', t => {
   let count = 0
   const store = composeBundlesRaw({
     ...countBundle,
-    init(store) {
+    init (store) {
       // being explicit here for documentation purposes
       const unsubscribe = store.subscribe(() => {
         count++

--- a/test/destroy.js
+++ b/test/destroy.js
@@ -3,7 +3,7 @@ const { composeBundles, composeBundlesRaw } = require('../dist/redux-bundler')
 
 const countBundle = {
   name: 'count',
-  selectDestroyable: state => state.destroyable,
+  selectCount: state => state.count,
   reducer: (state = 0, { type }) => (type === 'INC' ? state + 1 : state)
 }
 
@@ -48,13 +48,13 @@ test('calls return of init as the destroy of store', t => {
   t.equal(count, 0)
 
   store.dispatch({ type: 'INC' })
-  t.equal(store.getState().count, 1)
+  t.equal(store.selectCount(), 1)
   t.equal(count, 1)
 
   store.destroy()
 
   store.dispatch({ type: 'INC' })
-  t.equal(store.getState().count, 2)
+  t.equal(store.selectCount(), 2)
   t.equal(count, 1, 'destroy should have unsubscribed')
 
   t.end()


### PR DESCRIPTION
**TL;DR**
`store.destroy()` to remove event listeners, unsubscribe from store listeners or cleanup state.

**Synopsis**
This feature has 2 interfaces: either return a function from `bundle.init()` or explicitly declare `bundle.destroy()`. Both also work together. It is a 1-way final method - no option to revert or re-initialize the store again. See `test/destroy.js` for reference.