### PR TITLE
Add ignoreActions option to createDebugBundle

### DIFF
--- a/docs/api/included-bundles.md
+++ b/docs/api/included-bundles.md
@@ -14,6 +14,7 @@ It takes the following options (none are required):
 - `logState` (default: true): whether to log state after each dispatch
 - `logIdle` (default: true): whether to log APP_IDLE events (these can get annoying if there's a lot).
 - `enabled` (default: HAS_DEBUG_FLAG): explicitly enable/disable. This is helpful in node.js where there's no localStorage flag.
+- `ignoreActions` (default: []): an array of actions to ignore when logging.
 
 If enabled:
 

--- a/src/bundles/create-debug-bundle.js
+++ b/src/bundles/create-debug-bundle.js
@@ -18,7 +18,8 @@ export default spec => {
     logSelectors: true,
     logState: true,
     logIdle: true,
-    enabled: HAS_DEBUG_FLAG
+    enabled: HAS_DEBUG_FLAG,
+    ignoreActions: []
   }
 
   const opts = Object.assign({}, defaultOpts, spec)
@@ -52,7 +53,11 @@ export default spec => {
     },
     selectIsDebug: state => state.debug,
     getMiddleware: () => store => next => action => {
-      if (!opts.logIdle && action.type === 'APP_IDLE') {
+      if (!opts.logIdle) {
+        opts.ignoreActions.push('APP_IDLE')
+      }
+
+      if (opts.ignoreActions.includes(action.type)) {
         return next(action)
       }
 


### PR DESCRIPTION
Along the lines of ignoring APP_IDLE events, I thought this might be useful for other custom actions that are dispatched often.

createDebugBundle({ignoreActions: ['GEOLOCATION_SUCCESS']})