### PR TITLE
docs: update not-found route to use correct route definition

### DIFF
--- a/docs/api/included-bundles.md
+++ b/docs/api/included-bundles.md
@@ -93,7 +93,7 @@ export default createRouteBundle({
   '/': Home,
   '/users': UserList,
   '/users/:userId': UserDetail,
-  '*': NotFound
+  '/*': NotFound
 })
 ```
 


### PR DESCRIPTION
- feather-route-matcher does not seem to match a route with '*' and I noticed its documentation uses `/*` for a catch all route